### PR TITLE
Bump symfony/filesystem version to 5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	},
 	"require": {
 		"intervention/image": "^2.4",
-		"symfony/filesystem": "^2.8",
+		"symfony/filesystem": "^5.1",
 		"afterlogic/mailso": "^1.4",
 		"phpixie/cache": "^3.0",
 		"phpixie/filesystem": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	},
 	"require": {
 		"intervention/image": "^2.4",
-		"symfony/filesystem": "^5.1",
+		"symfony/filesystem": "^4.4",
 		"afterlogic/mailso": "^1.4",
 		"phpixie/cache": "^3.0",
 		"phpixie/filesystem": "^3.0",


### PR DESCRIPTION
Not sure why this is in required since it is not used in the code. I can see that `phpixie/filesystem` is in use.