### PR TITLE
Fixed multiple includes of module classes in certain installs

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -43,7 +43,7 @@ spl_autoload_register(function ($sClassName) {
 	if (strpos($sClassName, 'Aurora\\Modules') !== false)
 	{
 		$sModuleClassName = substr($sClassName, strlen('Aurora\\Modules\\'));
-		$sModuleName = substr($sModuleClassName, 0, -7);
+		$sModuleName = substr($sModuleClassName, 0, strpos($sModuleClassName, '\\'));
 		$sFileName = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . $sModuleName . DIRECTORY_SEPARATOR . 'Module.php';
 		if (file_exists($sFileName))
 		{


### PR DESCRIPTION
Remove hard coded -7 from substr.  This is called for including Module.php and Manager.php.  Module has only 6 letters which results in an extra \ on the end of the module name for Module.php, and the correct name for Manager.php.  In certain installations this results in include_once trying to include the same file multiple times.